### PR TITLE
Add "Warning: " prefix to messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default function warning(condition: mixed, message: string) {
     // check console for IE9 support which provides console
     // only with open devtools
     if (typeof console !== 'undefined') {
-      console.warn(message);
+      console.warn('Warning: ' + message);
     }
     try {
       // --- Welcome to debugging React ---

--- a/test/bundle-size.spec.js
+++ b/test/bundle-size.spec.js
@@ -3,7 +3,7 @@ import { rollup } from 'rollup';
 import babel from 'rollup-plugin-babel';
 import replace from 'rollup-plugin-replace';
 
-const DEV_SIZE = 251;
+const DEV_SIZE = 265;
 const PROD_SIZE = 66;
 
 type GetCodeArgs = {|

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -24,7 +24,7 @@ it('should log a warning if the condition is falsy', () => {
     const message: string = `hey ${String(value)}`;
     warning(value, message);
 
-    expect(console.warn).toHaveBeenCalledWith(message);
+    expect(console.warn).toHaveBeenCalledWith('Warning: ' + message);
     console.warn.mockClear();
   });
 });


### PR DESCRIPTION
Need this to be compatible with `warning`

See https://github.com/BerkeleyTrue/warning/blob/master/warning.js#L29