### PR TITLE
Add check for `process` identifier prior to using it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-const isProduction: boolean = process.env.NODE_ENV === 'production';
+const isProduction: boolean = (typeof process !== 'undefined') && (process.env.NODE_ENV === 'production');
 
 export default function warning(condition: mixed, message: string): void {
   // don't do anything in production


### PR DESCRIPTION
Closes #24  

Browsers do not have the `process` "global" so this adds a check prior to using it.