### PR TITLE
feat: explicitly import process object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import process from 'process';
+
 // @flow
 const isProduction: boolean = process.env.NODE_ENV === 'production';
 


### PR DESCRIPTION
This imports the `process` global as recommended in the Node.js documentation at https://nodejs.org/dist/latest-v16.x/docs/api/process.html#process_process.

Using this pattern allows code to not assume the global, and eases support for running this code in the browser and other JS environments like Deno.